### PR TITLE
Minor improvements

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  code_quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --check
+      - run: cargo clippy
+  build:
+    strategy:
+      matrix:
+        toolchain: [stable, beta, nightly]
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcomponent"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/jschwe/xcomponent.git"
 description = "Experimental bindings of the OpenHarmonyOS ArkUI XComponent"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,7 @@ use crate::log::error;
 use ohos_sys::ace::xcomponent::native_interface_xcomponent::OH_NativeXComponent_GetXComponentSize;
 use ohos_sys::{
     ace::xcomponent::native_interface_xcomponent::{
-        OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetTouchEvent,
-        OH_NativeXComponent_RegisterCallback, OH_NativeXComponent_TouchEvent,
+        OH_NativeXComponent, OH_NativeXComponent_GetTouchEvent, OH_NativeXComponent_TouchEvent,
     },
     native_window::OHNativeWindow,
 };
@@ -81,28 +80,6 @@ impl<'a> XComponent<'a> {
         };
 
         Ok(touch_event)
-    }
-
-    pub fn register_callback(
-        &mut self,
-        callbacks: OH_NativeXComponent_Callback,
-    ) -> Result<(), i32> {
-        // Fixme: Leaking the box fixes a crash in release mode.
-        // I would expect `OH_NativeXComponent_RegisterCallback` to copy the callbacks
-        // synchronously, so the struct shouldn't need to be leaked, and we should be able to
-        // use a reference to the stack.
-        // This should be investigated at a later point in time, to avoid the leaking.
-        let boxed = Box::new(callbacks);
-        unsafe {
-            let res = OH_NativeXComponent_RegisterCallback(
-                self.xcomponent.as_ptr(),
-                Box::leak(boxed) as *mut _,
-            );
-            if res != 0 {
-                return Err(res);
-            }
-        }
-        Ok(())
     }
 
     /// Returns the size of the XComponent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,31 @@
+//! An abstraction over the OpenHarmony [XComponent]
+//!
+//! ## Example
+//! ```
+//! # use ohos_sys::ace::xcomponent::native_interface_xcomponent::OH_NativeXComponent;
+//! # use core::ffi::c_void;
+//! pub extern "C" fn on_surface_created_cb(xcomponent: *mut OH_NativeXComponent, window: *mut c_void) {
+//!     let xc = xcomponent::XComponent::new(xcomponent, window).expect("Invalid XC");
+//!     let size = xc.size();
+//!     // do something with the xcomponent ...
+//! }
+//!
+//! pub extern "C" fn on_dispatch_touch_event_cb(
+//!     component: *mut OH_NativeXComponent,
+//!     window: *mut c_void,
+//! ) {
+//!      let xc = xcomponent::XComponent::new(component, window).unwrap();
+//!      let touch_event = xc.get_touch_event().unwrap();
+//!      // Handle the touch event ....
+//! }
+//! ```
+//!
+//! ## Features
+//!
+//! * log: Outputs error and diagnostic messages via the `log` crate if enabled.
+//!
+//! [XComponent]: https://gitee.com/openharmony/docs/blob/master/zh-cn/application-dev/ui/napi-xcomponent-guidelines.md
+
 use core::{ffi::c_void, marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
 
 use crate::log::error;


### PR DESCRIPTION
- Add safe method to retrieve the size of an XComponent
- Add some documentation
- Remove `register_xcomponent_callbacks`, since that implementation was wrong and untested.
- formatting